### PR TITLE
Handle exception in get_ruleset_matches response

### DIFF
--- a/koodous/koodous.py
+++ b/koodous/koodous.py
@@ -168,7 +168,7 @@ class Koodous(object):
                                 verify=REQUESTS_CA_BUNDLE)
 
             # If valid response, get json content
-            if response.status_code == 200:
+            if 200 <= response.status_code < 400:
                 to_yield = response.json()
             else:
                 raise Exception("Couldn't get ruleset matches: %s" % response.text)

--- a/koodous/koodous.py
+++ b/koodous/koodous.py
@@ -166,7 +166,13 @@ class Koodous(object):
         while next_url:
             response = requests.get(url=next_url, headers=self.headers,
                                 verify=REQUESTS_CA_BUNDLE)
-            to_yield = response.json()
+
+            # If valid response, get json content
+            if response.status_code == 200:
+                to_yield = response.json()
+            else:
+                raise Exception("Couldn't get ruleset matches: %s" % response.text)
+
             next_url = to_yield['next']
             del to_yield['next']
             del to_yield['previous']


### PR DESCRIPTION
Check for 200 response and raise exception before response.json()
Avoids simplejson.errors.JSONDecodeError