### PR TITLE
Solve a small mistake in the BASE_URL

### DIFF
--- a/koodous/koodous.py
+++ b/koodous/koodous.py
@@ -34,7 +34,7 @@ from . import utils
 
 __author__ = "Antonio Sanchez <asanchez@koodous.com>"
 
-BASE_URL = 'https://api.koodous.com/'
+BASE_URL = 'https://api.koodous.com'
 
 REQUESTS_CA_BUNDLE = certifi.where()
 


### PR DESCRIPTION
the value of BASE_URL used to be 'https://api.koodous.com/'
when it was placed in the other functions, two "/" were formed and put next to each other in the URL, which prevented the request from getting a response from the server.
I changed the value of BASE_URL to 'https://api.koodous.com' and the problem has been solved.